### PR TITLE
Add units (metric/imperial) option

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -23,6 +23,16 @@
       "default_value": " "
     },
     {
+      "id": "units",
+      "type": "select",
+      "name": "Units",
+      "default_value": "metric",
+      "options": [
+        { "value": "metric", "text": "Metric" },
+        { "value": "imperial", "text": "Imperial" }
+      ]
+    },
+    {
       "id": "predef_cities",
       "type": "text",
       "name": "Predefined cities",


### PR DESCRIPTION
First off, thanks for the extension!

I use imperial units for weather 🙂 so I added select options for `Metric` and `Imperial`. Still defaults to `Metric`.

I added `self.temp_symbol` (either `°C` or `°F` depending on selected units) replacing `'...%sC' % (...chr(176))`.